### PR TITLE
Fixed bug with root relative paths

### DIFF
--- a/flaskext/versioned/__init__.py
+++ b/flaskext/versioned/__init__.py
@@ -33,9 +33,11 @@ class FileChangedDriver(Driver):
 
     def version(self, stream):
         path = stream
-        if os.path.isabs(path):
-            pass
-        else:
+        if os.path.isabs(path) and not os.path.isfile(path):
+            if path.startswith('/'):
+                path = path[1:]
+                stream = path
+
             path = os.path.join(self.app.root_path, path)
 
         if not os.path.isfile(path):

--- a/test_versioned.py
+++ b/test_versioned.py
@@ -41,3 +41,9 @@ class VersionedTestCase(unittest.TestCase):
         path = 'flaskext'
         assert os.path.isdir(path)
         self.assertRaises(VersionedError, self.versioned, path)
+
+    def test_04_existing_file_root_relative(self):
+        path = '/setup.py'
+        versioned_path = self.versioned(path)
+        assert versioned_path.startswith('/version-')
+        assert versioned_path.endswith(path)


### PR DESCRIPTION
If you passed a root relative path to flask-versioned (such as `/static/myfile.css`) it would throw an error that the file did not exist, since it thought that it was an absolute path that you passed.

This is my suggested fix to that bug (all unit tests are passing, including the new one).
